### PR TITLE
Use /usr/bin/env not /bin/env

### DIFF
--- a/wsbench
+++ b/wsbench
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 var OptionParser = require('./lib/optparse').OptionParser;
 var sys = require('sys');


### PR DESCRIPTION
Not all platforms have the `env` script located (or symlinked) at `/bin/env`
but it is fairly standard for all UNIX and UNIX-likes (e.g. Linux distros, BSDs, OS X)
to have it located or symlinked in `/usr/bin/env`.
